### PR TITLE
Add dataset loading and preprocessing pipeline with tests

### DIFF
--- a/bank_ml/data.py
+++ b/bank_ml/data.py
@@ -1,15 +1,89 @@
 """Data loading utilities."""
+
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Optional, Tuple
 
 import pandas as pd
+from loguru import logger
+from sklearn.model_selection import StratifiedKFold, train_test_split
+
+from .config import Config
 
 
-def load_csv(path: Path | str, label: str, id_column: Optional[str] = None) -> Tuple[pd.DataFrame, pd.Series]:
-    """Load a CSV file and split into features and target."""
+def load_csv(
+    path: Path | str, label: str, id_column: Optional[str] = None
+) -> Tuple[pd.DataFrame, pd.Series]:
+    """Load a CSV file and split into features and target.
+
+    Parameters
+    ----------
+    path:
+        Path to the CSV file.
+    label:
+        Name of the target column.
+    id_column:
+        Optional column containing row identifiers. If provided, the column is
+        used as the index of the returned data but excluded from the feature
+        matrix.
+    """
+
+    path = Path(path)
     df = pd.read_csv(path)
+    if label not in df.columns:
+        raise ValueError(f"Label column '{label}' not found in {path}")
+
     y = df[label]
     X = df.drop(columns=[label])
-    if id_column and id_column in X.columns:
+
+    if id_column and id_column in df.columns:
+        ids = df[id_column]
         X = X.drop(columns=[id_column])
+        X.index = ids
+        y.index = ids
+
+    logger.debug(
+        "Loaded CSV %s with %d rows and %d columns", path, X.shape[0], X.shape[1] + 1
+    )
     return X, y
+
+
+def load_dataset(cfg: Config) -> Tuple[pd.DataFrame, pd.Series]:
+    """Load the dataset defined by a :class:`Config` object.
+
+    Parameters
+    ----------
+    cfg:
+        Configuration object specifying paths and column names.
+    """
+
+    return load_csv(cfg.paths.input_csv, cfg.label, cfg.id_column)
+
+
+def train_test_cv_split(
+    X: pd.DataFrame, y: pd.Series, cfg: Config
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series, StratifiedKFold]:
+    """Perform a train/test split and build a cross-validation splitter.
+
+    Returns the training and test partitions along with a ``StratifiedKFold``
+    object configured according to ``cfg.cv``.
+    """
+
+    logger.debug(
+        "Splitting data: test_size=%s, random_state=%s", cfg.cv.test_size, cfg.cv.random_state
+    )
+    X_train, X_test, y_train, y_test = train_test_split(
+        X,
+        y,
+        test_size=cfg.cv.test_size,
+        random_state=cfg.cv.random_state,
+        stratify=y,
+    )
+
+    cv = StratifiedKFold(
+        n_splits=cfg.cv.n_splits,
+        shuffle=True,
+        random_state=cfg.cv.random_state,
+    )
+    return X_train, X_test, y_train, y_test, cv

--- a/bank_ml/preprocess.py
+++ b/bank_ml/preprocess.py
@@ -1,13 +1,29 @@
 """Preprocessing utilities."""
-from typing import Tuple
 
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+import joblib
+import numpy as np
 import pandas as pd
+from loguru import logger
 from imblearn.over_sampling import SMOTE
+from sklearn.base import clone
+from sklearn.compose import ColumnTransformer
+from sklearn.impute import SimpleImputer
 from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import MinMaxScaler, OneHotEncoder
 
 
-def train_test_split_data(X: pd.DataFrame, y: pd.Series, test_size: float, random_state: int) -> Tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series]:
-    return train_test_split(X, y, test_size=test_size, random_state=random_state, stratify=y)
+def train_test_split_data(
+    X: pd.DataFrame, y: pd.Series, test_size: float, random_state: int
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series]:
+    return train_test_split(
+        X, y, test_size=test_size, random_state=random_state, stratify=y
+    )
 
 
 def handle_imbalance(X: pd.DataFrame, y: pd.Series, method: str) -> Tuple[pd.DataFrame, pd.Series]:
@@ -15,3 +31,104 @@ def handle_imbalance(X: pd.DataFrame, y: pd.Series, method: str) -> Tuple[pd.Dat
         sampler = SMOTE(random_state=0)
         return sampler.fit_resample(X, y)
     return X, y
+
+
+# ---------------------------------------------------------------------------
+# Column type detection and preprocessing pipelines
+# ---------------------------------------------------------------------------
+
+def _detect_column_types(X: pd.DataFrame) -> Tuple[List[str], List[str]]:
+    """Return lists of numeric and categorical column names.
+
+    Object, category and boolean dtypes are treated as categorical.
+    """
+
+    categorical_cols = X.select_dtypes(
+        include=["object", "category", "bool"]
+    ).columns.tolist()
+    numeric_cols = [c for c in X.columns if c not in categorical_cols]
+    return numeric_cols, categorical_cols
+
+
+def build_preprocess(X: pd.DataFrame) -> Tuple[Pipeline, List[str]]:
+    """Build a preprocessing pipeline for the given DataFrame.
+
+    Parameters
+    ----------
+    X:
+        Input feature matrix.
+
+    Returns
+    -------
+    pipeline:
+        An ``sklearn`` :class:`Pipeline` performing imputation, scaling and
+        encoding.
+    feature_names:
+        Names of the output features produced by the pipeline.
+    """
+
+    numeric_cols, categorical_cols = _detect_column_types(X)
+    logger.debug("Numeric columns detected: %s", numeric_cols)
+    logger.debug("Categorical columns detected: %s", categorical_cols)
+
+    numeric_pipeline = Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="median")),
+            ("scaler", MinMaxScaler()),
+        ]
+    )
+
+    categorical_pipeline = Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="most_frequent")),
+            (
+                "encoder",
+                OneHotEncoder(handle_unknown="ignore", sparse_output=False),
+            ),
+        ]
+    )
+
+    preprocessor = ColumnTransformer(
+        transformers=[
+            ("num", numeric_pipeline, numeric_cols),
+            ("cat", categorical_pipeline, categorical_cols),
+        ]
+    )
+
+    pipeline = Pipeline([("preprocess", preprocessor)])
+
+    # Fit a clone of the transformer to determine feature names without
+    # mutating the returned pipeline
+    preprocessor_clone = clone(preprocessor).fit(X)
+    feature_names = list(preprocessor_clone.get_feature_names_out())
+
+    return pipeline, feature_names
+
+
+def fit_transform_preprocess(pipeline: Pipeline, X: pd.DataFrame) -> np.ndarray:
+    """Fit the preprocessing pipeline and transform the data."""
+
+    logger.debug("Fitting and transforming data with preprocessing pipeline")
+    return pipeline.fit_transform(X)
+
+
+def transform_preprocess(pipeline: Pipeline, X: pd.DataFrame) -> np.ndarray:
+    """Transform new data with an already fitted pipeline."""
+
+    logger.debug("Transforming data with fitted preprocessing pipeline")
+    return pipeline.transform(X)
+
+
+def save_preprocess(pipeline: Pipeline, path: Path | str) -> None:
+    """Persist a fitted preprocessing pipeline to disk."""
+
+    joblib.dump(pipeline, path)
+    logger.info("Saved preprocessing pipeline to %s", path)
+
+
+def load_preprocess(path: Path | str) -> Pipeline:
+    """Load a previously persisted preprocessing pipeline."""
+
+    pipeline = joblib.load(path)
+    logger.info("Loaded preprocessing pipeline from %s", path)
+    return pipeline

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pandas as pd
+
+from bank_ml.preprocess import (
+    build_preprocess,
+    fit_transform_preprocess,
+    transform_preprocess,
+)
+
+
+def test_preprocess_pipeline_smoke():
+    """Pipeline should fit and transform a tiny dataset."""
+
+    X = pd.DataFrame(
+        {
+            "num": [1.0, 2.0, None, 4.0],
+            "cat": ["a", "b", "a", None],
+            "flag": [True, False, True, False],
+        }
+    )
+
+    pipeline, feature_names = build_preprocess(X)
+    Xt = fit_transform_preprocess(pipeline, X)
+
+    assert Xt.shape[0] == X.shape[0]
+    assert Xt.shape[1] == len(feature_names)
+
+    Xt2 = transform_preprocess(pipeline, X)
+    np.testing.assert_allclose(Xt, Xt2)
+


### PR DESCRIPTION
## Summary
- implement configuration-aware dataset loading and train/test splitting helpers
- build robust preprocessing pipeline with imputation, scaling and one-hot encoding
- add pytest config and smoke tests for preprocessing pipeline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e9ef1a568833284c5118184791f80