### PR TITLE
Implement full training pipeline and demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: demo
+
+demo:
+	python -m bank_ml.cli fit --config demo-config.yaml

--- a/README.md
+++ b/README.md
@@ -29,3 +29,50 @@ bank-ml report --config config.yaml
 ```
 
 Configuration files are YAML and follow the structure described in `bank_ml/config.py`.
+
+### Minimal `config.yaml`
+
+```yaml
+paths:
+  input_csv: PATH_TO_CSV
+  output_dir: ./outputs/run1
+label: Label_LoanDefault
+id_column: CustomerID
+cv:
+  n_splits: 5
+  test_size: 0.3
+  random_state: 42
+imbalance:
+  method: class_weight
+ga:
+  pop: 20
+  gens: 15
+  cx_prob: 0.8
+  mut_prob: 0.1
+clustering:
+  k_grid: [2,3,4,5,6]
+  n_init: 15
+  max_iter: 300
+pso:
+  particles: 16
+  iters: 20
+mlp_bounds:
+  hidden1: [16, 64]
+  hidden2: [16, 64]
+  lr: [0.0001, 0.05]
+  alpha: [1e-6, 1e-3]
+  momentum: [0.5, 0.95]
+  activation_choices: ["logistic","tanh","relu"]
+```
+
+### Demo
+
+A small demo dataset (`banking_dataset.csv`) is bundled with the repository. Run
+the full pipeline using the provided `demo-config.yaml` via:
+
+```bash
+make demo
+```
+
+The outputs (models, metrics, report and plots) will be written to
+`outputs/run1` and `assets`.

--- a/bank_ml/config.py
+++ b/bank_ml/config.py
@@ -64,6 +64,14 @@ def load_config(path: Path | str) -> Config:
     path = Path(path)
     with path.open("r") as fh:
         data = yaml.safe_load(fh) or {}
+
+    # Allow ``imbalance`` to be specified either as a plain string or as a
+    # mapping with a ``method`` field.  The README examples use the latter form
+    # for readability, so we normalise it here for the ``Config`` model.
+    imb = data.get("imbalance")
+    if isinstance(imb, dict) and "method" in imb:
+        data["imbalance"] = imb["method"]
+
     return Config.model_validate(data)
 
 

--- a/bank_ml/models.py
+++ b/bank_ml/models.py
@@ -151,7 +151,8 @@ def train_models(
     # Persist models -----------------------------------------------------
     out_dir = Path(cfg.paths.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    joblib.dump(mlp, out_dir / "mlp_model.joblib")
+    # Persist tuned MLP under a simple and predictable name
+    joblib.dump(mlp, out_dir / "mlp.joblib")
     for name, model in baselines.items():
         joblib.dump(model, out_dir / f"{name}.joblib")
 

--- a/demo-config.yaml
+++ b/demo-config.yaml
@@ -1,0 +1,30 @@
+paths:
+  input_csv: banking_dataset.csv
+  output_dir: outputs/run1
+label: Label_LoanDefault
+id_column: CustomerID
+cv:
+  n_splits: 5
+  test_size: 0.3
+  random_state: 42
+imbalance:
+  method: class_weight
+ga:
+  pop: 20
+  gens: 15
+  cx_prob: 0.8
+  mut_prob: 0.1
+clustering:
+  k_grid: [2,3,4,5,6]
+  n_init: 15
+  max_iter: 300
+pso:
+  particles: 16
+  iters: 20
+mlp_bounds:
+  hidden1: [16, 64]
+  hidden2: [16, 64]
+  lr: [0.0001, 0.05]
+  alpha: [1e-6, 1e-3]
+  momentum: [0.5, 0.95]
+  activation_choices: ["logistic","tanh","relu"]


### PR DESCRIPTION
## Summary
- expose full end-to-end `fit` command that saves GA selection, clustering model, tuned MLP, baselines and a markdown report
- support YAML configs with `imbalance.method` and persist MLP as `mlp.joblib`
- add minimal config example, demo config and `make demo` target

## Testing
- `pytest -q`
- `make demo`


------
https://chatgpt.com/codex/tasks/task_e_689eaf0302608332b79197cd6beda865